### PR TITLE
Use ItemStack instances instead of mutating ItemStack.EMPTY

### DIFF
--- a/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/drill/EnchantableDrillMovementBehaviour.kt
+++ b/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/drill/EnchantableDrillMovementBehaviour.kt
@@ -13,6 +13,7 @@ import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.core.BlockPos
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.Enchantments
 
@@ -28,7 +29,7 @@ class EnchantableDrillMovementBehaviour : DrillMovementBehaviour() {
     }
 
     override fun getBlockBreakingSpeed(context: MovementContext): Float {
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context.blockEntityData
         })
         return super.getBlockBreakingSpeed(context) * ((enchantments[Enchantments.BLOCK_EFFICIENCY] ?: 0) + 1)

--- a/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/harvester/EnchantableHarvesterMovementBehaviour.kt
+++ b/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/harvester/EnchantableHarvesterMovementBehaviour.kt
@@ -53,7 +53,7 @@ class EnchantableHarvesterMovementBehaviour : HarvesterMovementBehaviour() {
             else return
         }
 
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context.blockEntityData
         }).map { EnchantmentInstance(it.key, it.value) }
         var item = EnchantedItemFactory.getPickaxeItemStack(*enchantments.toTypedArray())

--- a/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/plough/EnchantablePloughMovementBehaviour.kt
+++ b/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/plough/EnchantablePloughMovementBehaviour.kt
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.core.BlockPos
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.EnchantmentInstance
 import net.minecraft.world.item.enchantment.Enchantments
@@ -20,7 +21,7 @@ class EnchantablePloughMovementBehaviour : PloughMovementBehaviour() {
     override fun destroyBlock(context: MovementContext?, breakingPos: BlockPos?) {
         val level = context?.world
         val enchantedItem = EnchantedItemFactory.getHoeItemStack(
-            *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+            *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
                 .map { EnchantmentInstance(it.key, it.value) }
                 .toTypedArray()
         )
@@ -33,7 +34,7 @@ class EnchantablePloughMovementBehaviour : PloughMovementBehaviour() {
     }
 
     override fun getBlockBreakingSpeed(context: MovementContext?): Float {
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context?.blockEntityData
         })
         return super.getBlockBreakingSpeed(context) * ((enchantments[Enchantments.BLOCK_EFFICIENCY] ?: 0) + 1)

--- a/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/roller/EnchantableRollerMovementBehaviour.kt
+++ b/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/roller/EnchantableRollerMovementBehaviour.kt
@@ -14,6 +14,7 @@ import net.minecraft.core.BlockPos
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.tags.BlockTags
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.Enchantments
 
@@ -43,7 +44,7 @@ class EnchantableRollerMovementBehaviour : RollerMovementBehaviour() {
         val fakePlayer = if (level is ServerLevel) {
             ContraptionBlockBreaker(level, context)
         } else null
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context.blockEntityData
         })
         BlockHelper.destroyBlockAs(context.world, breakingPos, fakePlayer, fakePlayer?.mainHandItem, 1f) {
@@ -57,7 +58,7 @@ class EnchantableRollerMovementBehaviour : RollerMovementBehaviour() {
 
     override fun getBlockBreakingSpeed(context: MovementContext?): Float {
         val speed = super.getBlockBreakingSpeed(context)
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context?.blockEntityData
         })
         return speed * ((enchantments[Enchantments.BLOCK_EFFICIENCY] ?: 0) + 1)

--- a/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/saw/EnchantableSawMovementBehaviour.kt
+++ b/common/src/main/java/io/github/cotrin8672/createenchantablemachinery/content/block/saw/EnchantableSawMovementBehaviour.kt
@@ -12,6 +12,7 @@ import net.minecraft.core.BlockPos
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.tags.BlockTags
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.Enchantments
 import net.minecraft.world.level.block.state.BlockState
@@ -48,7 +49,7 @@ class EnchantableSawMovementBehaviour : SawMovementBehaviour() {
     }
 
     override fun getBlockBreakingSpeed(context: MovementContext): Float {
-        val enchantments = EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply {
+        val enchantments = EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply {
             tag = context.blockEntityData
         })
         return super.getBlockBreakingSpeed(context) * ((enchantments[Enchantments.BLOCK_EFFICIENCY] ?: 0) + 1)

--- a/fabric/src/main/java/io/github/cotrin8672/createenchantablemachinery/fabric/platform/entity/ContraptionBlockBreakPlayer.kt
+++ b/fabric/src/main/java/io/github/cotrin8672/createenchantablemachinery/fabric/platform/entity/ContraptionBlockBreakPlayer.kt
@@ -6,6 +6,7 @@ import io.github.cotrin8672.createenchantablemachinery.util.EnchantedItemFactory
 import net.fabricmc.fabric.api.entity.FakePlayer
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.EnchantmentInstance
 import net.minecraft.world.phys.Vec3
@@ -16,7 +17,7 @@ private constructor(
     level: ServerLevel,
     private var context: MovementContext?,
     private var heldItem: ItemStack = EnchantedItemFactory.getPickaxeItemStack(
-        *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+        *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
             .map { EnchantmentInstance(it.key, it.value) }
             .toTypedArray()
     ),
@@ -28,7 +29,7 @@ private constructor(
             level: ServerLevel,
             context: MovementContext?,
             heldItem: ItemStack = EnchantedItemFactory.getPickaxeItemStack(
-                *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+                *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
                     .map { EnchantmentInstance(it.key, it.value) }
                     .toTypedArray()
             ),
@@ -38,7 +39,7 @@ private constructor(
             } else {
                 instance.setMovementContext(context)
                 instance.heldItem = EnchantedItemFactory.getPickaxeItemStack(
-                    *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+                    *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
                         .map { EnchantmentInstance(it.key, it.value) }
                         .toTypedArray())
             }

--- a/forge/src/main/java/io/github/cotrin8672/createenchantablemachinery/forge/platform/entity/ContraptionBlockBreakPlayer.kt
+++ b/forge/src/main/java/io/github/cotrin8672/createenchantablemachinery/forge/platform/entity/ContraptionBlockBreakPlayer.kt
@@ -5,6 +5,7 @@ import com.simibubi.create.content.contraptions.behaviour.MovementContext
 import io.github.cotrin8672.createenchantablemachinery.util.EnchantedItemFactory
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 import net.minecraft.world.item.enchantment.EnchantmentInstance
 import net.minecraft.world.phys.Vec3
@@ -16,7 +17,7 @@ private constructor(
     level: ServerLevel,
     private var context: MovementContext?,
     private val heldItem: ItemStack = EnchantedItemFactory.getPickaxeItemStack(
-        *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+        *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
             .map { EnchantmentInstance(it.key, it.value) }
             .toTypedArray()
     ),
@@ -34,7 +35,7 @@ private constructor(
             level: ServerLevel,
             context: MovementContext?,
             heldItem: ItemStack = EnchantedItemFactory.getPickaxeItemStack(
-                *EnchantmentHelper.getEnchantments(ItemStack.EMPTY.apply { tag = context?.blockEntityData })
+                *EnchantmentHelper.getEnchantments(ItemStack(Items.AIR).apply { tag = context?.blockEntityData })
                     .map { EnchantmentInstance(it.key, it.value) }
                     .toTypedArray()
             ),


### PR DESCRIPTION
This fixes #103 where all enchantments were being applied to the global instance of `ItemStack.EMPTY`. This was being caused by `ItemStack.EMPTY.apply` calls mutating the original reference of the item stack.

It turns out this affected more than just the drills and silk touch, so I went ahead and replaced all instances of this mutation.